### PR TITLE
Refactor/add missing method

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "type:check": "tsc --noEmit",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "prepare": "npx simple-git-hooks"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^10.0.1",
@@ -55,6 +56,7 @@
     "cypress": "^9.5.1",
     "cypress-file-upload": "^5.0.8",
     "eslint": "7.32.0",
+    "simple-git-hooks": "^2.13.1",
     "typescript": "^4.3.2",
     "vite": "^2.4.2",
     "vite-plugin-css-injected-by-js": "^2.1.1",

--- a/src/editor/DOMEventHandlers.ts
+++ b/src/editor/DOMEventHandlers.ts
@@ -1,19 +1,38 @@
 import Editor, {
-  ElementType,
+  EditorMode,
+  ICatalog,
   IEditorData,
   IEditorOption,
   IElement,
+  IWatermark,
+  ImageDisplay,
+  INavigateInfo,
   ListStyle,
   ListType,
+  PageMode,
+  PaperDirection,
   RowFlex,
-  TitleLevel
+  TableBorder,
+  TitleLevel,
+  VerticalAlign
 } from '.'
-import { Dialog } from '../components/dialog/Dialog'
 import en from '../editor/core/i18n/lang/en.json'
-import { IDrawImagePayload } from './interface/Draw'
+import {
+  IAppendElementListOption,
+  IDrawImagePayload,
+  IGetValueOption,
+  IPainterOption
+} from './interface/Draw'
+import { IEditorHTML } from './interface/Editor'
+import { IMargin } from './interface/Margin'
+import { RangeContext } from './interface/Range'
 
 export class DOMEventHandlers {
   private static instance: Editor
+
+  private static getCommand() {
+    return DOMEventHandlers.getEditorInstance().command
+  }
 
   static getEditorInstance(): Editor {
     if (!DOMEventHandlers.instance) {
@@ -41,181 +60,119 @@ export class DOMEventHandlers {
       }
     }
     DOMEventHandlers.instance = new Editor(container, data, options)
-    DOMEventHandlers.instance.command.executeSetLocale('en')
+    DOMEventHandlers.getCommand().executeSetLocale('en')
     DOMEventHandlers.instance.register.langMap('en', en)
-    
+
     return DOMEventHandlers.instance
   }
 
   static handleUndo() {
-    DOMEventHandlers.getEditorInstance().command.executeUndo()
+    DOMEventHandlers.undo()
   }
 
   static handleRedo() {
-    DOMEventHandlers.getEditorInstance().command.executeRedo()
+    DOMEventHandlers.redo()
   }
 
   static handleBold() {
-    DOMEventHandlers.getEditorInstance().command.executeBold()
+    DOMEventHandlers.bold()
   }
 
   static handleItalic() {
-    DOMEventHandlers.getEditorInstance().command.executeItalic()
+    DOMEventHandlers.italic()
   }
 
   static handleUnderline() {
-    DOMEventHandlers.getEditorInstance().command.executeUnderline()
+    DOMEventHandlers.underline()
   }
 
   static handleStrikeout() {
-    DOMEventHandlers.getEditorInstance().command.executeStrikeout()
+    DOMEventHandlers.strikeout()
   }
 
   static handleSuperscript() {
-    DOMEventHandlers.getEditorInstance().command.executeSuperscript()
+    DOMEventHandlers.superscript()
   }
+
   static handleSubscript() {
-    DOMEventHandlers.getEditorInstance().command.executeSubscript()
+    DOMEventHandlers.subscript()
   }
 
   static handleFontFamily(fontFamily: string) {
-    DOMEventHandlers.getEditorInstance().command.executeFont(fontFamily)
+    DOMEventHandlers.font(fontFamily)
   }
 
   static handleAlign(alignment: RowFlex) {
-    switch (alignment) {
-      case RowFlex.LEFT: {
-        DOMEventHandlers.getEditorInstance().command.executeRowFlex(
-          RowFlex.LEFT
-        )
-        break
-      }
-      case RowFlex.RIGHT: {
-        DOMEventHandlers.getEditorInstance().command.executeRowFlex(
-          RowFlex.RIGHT
-        )
-        break
-      }
-      case RowFlex.CENTER: {
-        DOMEventHandlers.getEditorInstance().command.executeRowFlex(
-          RowFlex.CENTER
-        )
-        break
-      }
-      case RowFlex.ALIGNMENT: {
-        DOMEventHandlers.getEditorInstance().command.executeRowFlex(
-          RowFlex.ALIGNMENT
-        )
-        break
-      }
-      default:
-        DOMEventHandlers.getEditorInstance().command.executeRowFlex(
-          RowFlex.LEFT
-        )
-    }
+    DOMEventHandlers.rowFlex(alignment)
   }
 
-  static handleList(listType: ListType, listStyle: ListStyle) {
-    DOMEventHandlers.getEditorInstance().command.executeList(
-      listType,
-      listStyle
-    )
+  static handleList(listType: ListType | null, listStyle?: ListStyle) {
+    DOMEventHandlers.list(listType, listStyle)
   }
 
   static setFontColor(payload: string) {
-    DOMEventHandlers.getEditorInstance().command.executeColor(payload)
+    DOMEventHandlers.color(payload)
   }
 
   static highlightText(payload: string) {
-    DOMEventHandlers.getEditorInstance().command.executeHighlight(payload)
+    DOMEventHandlers.highlight(payload)
   }
 
   static setFont(payload: string) {
-    DOMEventHandlers.getEditorInstance().command.executeFont(payload)
+    DOMEventHandlers.font(payload)
   }
 
   static setSize(payload: number) {
-    DOMEventHandlers.getEditorInstance().command.executeSize(payload)
+    DOMEventHandlers.size(payload)
   }
 
   static increaseFontSize() {
-    DOMEventHandlers.getEditorInstance().command.executeSizeAdd()
+    DOMEventHandlers.sizeAdd()
   }
 
   static decreaseFontSize() {
-    DOMEventHandlers.getEditorInstance().command.executeSizeMinus()
+    DOMEventHandlers.sizeMinus()
   }
+
   static getContent() {
-    return DOMEventHandlers.getEditorInstance().command.getValue()
+    return DOMEventHandlers.getValue()
   }
 
   static setContent(payload: Partial<IEditorData>) {
-    DOMEventHandlers.getEditorInstance().command.executeSetValue(payload)
+    DOMEventHandlers.setValue(payload)
   }
 
   static createTable(payload: { rowIndex: number; colIndex: number }) {
-    DOMEventHandlers.getEditorInstance().command.executeInsertTable(
-      payload.rowIndex,
-      payload.colIndex
-    )
+    DOMEventHandlers.insertTable(payload.rowIndex, payload.colIndex)
   }
 
   static setTitle(payload: TitleLevel | null) {
-    DOMEventHandlers.getEditorInstance().command.executeTitle(payload)
+    DOMEventHandlers.title(payload)
   }
 
   static getContentStyles() {
-    return DOMEventHandlers.getEditorInstance().command.getContentStyles()
+    return DOMEventHandlers.getCommand().getContentStyles()
   }
 
   static setImage(payload: IDrawImagePayload) {
-    DOMEventHandlers.getEditorInstance().command.executeImage(payload)
+    DOMEventHandlers.image(payload)
   }
 
   static createHyperLink() {
-    new Dialog({
-      title: 'Link',
-      data: [
-        {
-          type: 'text',
-          label: 'Text',
-          name: 'name',
-          required: true,
-          placeholder: 'Enter text'
-        },
-        {
-          type: 'text',
-          label: 'URL',
-          name: 'url',
-          required: true,
-          placeholder: 'Enter URL'
-        }
-      ],
-      onConfirm: payload => {
-        const name = payload.find(p => p.name === 'name')?.value
-        if (!name) return
-        const url = payload.find(p => p.name === 'url')?.value
-        if (!url) return
-        DOMEventHandlers.getEditorInstance().command.executeHyperlink({
-          type: ElementType.HYPERLINK,
-          value: '',
-          url,
-          valueList: name.split('').map(n => ({
-            value: n,
-            size: 16
-          }))
-        })
-      }
-    })
+    DOMEventHandlers.globalHyperlink()
+  }
+
+  static createGlobalHyperLink() {
+    DOMEventHandlers.globalHyperlink()
   }
 
   static setHorizontalLine(payload: number[]) {
-    DOMEventHandlers.getEditorInstance().command.executeSeparator(payload)
+    DOMEventHandlers.separator(payload)
   }
 
   static setPaperMargins(payload: number[]) {
     const [topMargin, bottomMargin, leftMargin, rightMargin] = payload
-    DOMEventHandlers.getEditorInstance().command.executeSetPaperMargin([
+    DOMEventHandlers.setPaperMargin([
       Number(topMargin),
       Number(rightMargin),
       Number(bottomMargin),
@@ -224,13 +181,377 @@ export class DOMEventHandlers {
   }
 
   static getSelectedText() {
-    return DOMEventHandlers.getEditorInstance().command.getRangeText()
+    return DOMEventHandlers.getRangeText()
   }
 
   static insertElement(payload: string) {
-    const updatedPayload: IElement[] = [{ value: payload }]
-    DOMEventHandlers.getEditorInstance().command.executeInsertElementList(
-      updatedPayload
-    )
+    DOMEventHandlers.insertElementList([{ value: payload }])
+  }
+
+  static mode(payload: EditorMode) {
+    DOMEventHandlers.getCommand().executeMode(payload)
+  }
+
+  static cut() {
+    DOMEventHandlers.getCommand().executeCut()
+  }
+
+  static copy() {
+    DOMEventHandlers.getCommand().executeCopy()
+  }
+
+  static async paste() {
+    return DOMEventHandlers.getCommand().executePaste()
+  }
+
+  static selectAll() {
+    DOMEventHandlers.getCommand().executeSelectAll()
+  }
+
+  static backspace() {
+    DOMEventHandlers.getCommand().executeBackspace()
+  }
+
+  static setRange(startIndex: number, endIndex: number) {
+    DOMEventHandlers.getCommand().executeSetRange(startIndex, endIndex)
+  }
+
+  static undo() {
+    DOMEventHandlers.getCommand().executeUndo()
+  }
+
+  static redo() {
+    DOMEventHandlers.getCommand().executeRedo()
+  }
+
+  static painter(options: IPainterOption) {
+    DOMEventHandlers.getCommand().executePainter(options)
+  }
+
+  static applyPainterStyle() {
+    DOMEventHandlers.getCommand().executeApplyPainterStyle()
+  }
+
+  static format() {
+    DOMEventHandlers.getCommand().executeFormat()
+  }
+
+  static font(payload: string) {
+    DOMEventHandlers.getCommand().executeFont(payload)
+  }
+
+  static size(payload: number) {
+    DOMEventHandlers.getCommand().executeSize(payload)
+  }
+
+  static sizeAdd() {
+    DOMEventHandlers.getCommand().executeSizeAdd()
+  }
+
+  static sizeMinus() {
+    DOMEventHandlers.getCommand().executeSizeMinus()
+  }
+
+  static bold() {
+    DOMEventHandlers.getCommand().executeBold()
+  }
+
+  static italic() {
+    DOMEventHandlers.getCommand().executeItalic()
+  }
+
+  static underline() {
+    DOMEventHandlers.getCommand().executeUnderline()
+  }
+
+  static strikeout() {
+    DOMEventHandlers.getCommand().executeStrikeout()
+  }
+
+  static superscript() {
+    DOMEventHandlers.getCommand().executeSuperscript()
+  }
+
+  static subscript() {
+    DOMEventHandlers.getCommand().executeSubscript()
+  }
+
+  static color(payload: string) {
+    DOMEventHandlers.getCommand().executeColor(payload)
+  }
+
+  static highlight(payload: string) {
+    DOMEventHandlers.getCommand().executeHighlight(payload)
+  }
+
+  static title(payload: TitleLevel | null) {
+    DOMEventHandlers.getCommand().executeTitle(payload)
+  }
+
+  static list(listType: ListType | null, listStyle?: ListStyle) {
+    DOMEventHandlers.getCommand().executeList(listType, listStyle)
+  }
+
+  static rowFlex(payload: RowFlex) {
+    DOMEventHandlers.getCommand().executeRowFlex(payload)
+  }
+
+  static rowMargin(payload: number) {
+    DOMEventHandlers.getCommand().executeRowMargin(payload)
+  }
+
+  static insertTable(row: number, col: number) {
+    DOMEventHandlers.getCommand().executeInsertTable(row, col)
+  }
+
+  static insertTableTopRow() {
+    DOMEventHandlers.getCommand().executeInsertTableTopRow()
+  }
+
+  static insertTableBottomRow() {
+    DOMEventHandlers.getCommand().executeInsertTableBottomRow()
+  }
+
+  static insertTableLeftCol() {
+    DOMEventHandlers.getCommand().executeInsertTableLeftCol()
+  }
+
+  static insertTableRightCol() {
+    DOMEventHandlers.getCommand().executeInsertTableRightCol()
+  }
+
+  static deleteTableRow() {
+    DOMEventHandlers.getCommand().executeDeleteTableRow()
+  }
+
+  static deleteTableCol() {
+    DOMEventHandlers.getCommand().executeDeleteTableCol()
+  }
+
+  static deleteTable() {
+    DOMEventHandlers.getCommand().executeDeleteTable()
+  }
+
+  static mergeTableCell() {
+    DOMEventHandlers.getCommand().executeMergeTableCell()
+  }
+
+  static cancelMergeTableCell() {
+    DOMEventHandlers.getCommand().executeCancelMergeTableCell()
+  }
+
+  static tableTdVerticalAlign(payload: VerticalAlign) {
+    DOMEventHandlers.getCommand().executeTableTdVerticalAlign(payload)
+  }
+
+  static tableBorderType(payload: TableBorder) {
+    DOMEventHandlers.getCommand().executeTableBorderType(payload)
+  }
+
+  static tableTdBackgroundColor(payload: string) {
+    DOMEventHandlers.getCommand().executeTableTdBackgroundColor(payload)
+  }
+
+  static tableTdBorderBgTop(payload: string) {
+    DOMEventHandlers.getCommand().executeTableTdBorderBgTop(payload)
+  }
+
+  static tableTdBorderBgBottom(payload: string) {
+    DOMEventHandlers.getCommand().executeTableTdBorderBgBottom(payload)
+  }
+
+  static tableTdBorderBgLeft(payload: string) {
+    DOMEventHandlers.getCommand().executeTableTdBorderBgLeft(payload)
+  }
+
+  static tableTdBorderBgRight(payload: string) {
+    DOMEventHandlers.getCommand().executeTableTdBorderBgRight(payload)
+  }
+
+  static tableTdBorderWidthTop(payload: number) {
+    DOMEventHandlers.getCommand().executeTableTdBorderWidthTop(payload)
+  }
+
+  static tableTdBorderWidthLeft(payload: number) {
+    DOMEventHandlers.getCommand().executeTableTdBorderWidthLeft(payload)
+  }
+
+  static tableTdBorderWidthBottom(payload: number) {
+    DOMEventHandlers.getCommand().executeTableTdBorderWidthBottom(payload)
+  }
+
+  static tableTdBorderWidthRight(payload: number) {
+    DOMEventHandlers.getCommand().executeTableTdBorderWidthRight(payload)
+  }
+
+  static hyperlink(payload: IElement) {
+    DOMEventHandlers.getCommand().executeHyperlink(payload)
+  }
+
+  static getHyperlinkRange(): [number, number] | null {
+    return DOMEventHandlers.getCommand().getHyperlinkRange()
+  }
+
+  static deleteHyperlink() {
+    DOMEventHandlers.getCommand().executeDeleteHyperlink()
+  }
+
+  static cancelHyperlink() {
+    DOMEventHandlers.getCommand().executeCancelHyperlink()
+  }
+
+  static editHyperlink(url: string) {
+    DOMEventHandlers.getCommand().executeEditHyperlink(url)
+  }
+
+  static separator(payload: number[]) {
+    DOMEventHandlers.getCommand().executeSeparator(payload)
+  }
+
+  static pageBreak() {
+    DOMEventHandlers.getCommand().executePageBreak()
+  }
+
+  static addWatermark(payload: IWatermark) {
+    DOMEventHandlers.getCommand().executeAddWatermark(payload)
+  }
+
+  static deleteWatermark() {
+    DOMEventHandlers.getCommand().executeDeleteWatermark()
+  }
+
+  static image(payload: IDrawImagePayload) {
+    DOMEventHandlers.getCommand().executeImage(payload)
+  }
+
+  static search(payload: string | null) {
+    DOMEventHandlers.getCommand().executeSearch(payload)
+  }
+
+  static searchNavigatePre() {
+    DOMEventHandlers.getCommand().executeSearchNavigatePre()
+  }
+
+  static searchNavigateNext() {
+    DOMEventHandlers.getCommand().executeSearchNavigateNext()
+  }
+
+  static getSearchNavigateInfo(): INavigateInfo | null {
+    return DOMEventHandlers.getCommand().getSearchNavigateInfo()
+  }
+
+  static replace(payload: string) {
+    DOMEventHandlers.getCommand().executeReplace(payload)
+  }
+
+  static async print() {
+    return DOMEventHandlers.getCommand().executePrint()
+  }
+
+  static replaceImageElement(payload: string) {
+    DOMEventHandlers.getCommand().executeReplaceImageElement(payload)
+  }
+
+  static saveAsImageElement() {
+    DOMEventHandlers.getCommand().executeSaveAsImageElement()
+  }
+
+  static changeImageDisplay(element: IElement, display: ImageDisplay) {
+    DOMEventHandlers.getCommand().executeChangeImageDisplay(element, display)
+  }
+
+  static getImage(pixelRatio?: number): Promise<string[]> {
+    return DOMEventHandlers.getCommand().getImage(pixelRatio)
+  }
+
+  static getValue(options?: IGetValueOption) {
+    return DOMEventHandlers.getCommand().getValue(options)
+  }
+
+  static getHTML(): IEditorHTML {
+    return DOMEventHandlers.getCommand().getHTML()
+  }
+
+  static getWordCount(): Promise<number> {
+    return DOMEventHandlers.getCommand().getWordCount()
+  }
+
+  static getRangeText(): string {
+    return DOMEventHandlers.getCommand().getRangeText()
+  }
+
+  static getRangeContext(): RangeContext | null {
+    return DOMEventHandlers.getCommand().getRangeContext()
+  }
+
+  static pageMode(payload: PageMode) {
+    DOMEventHandlers.getCommand().executePageMode(payload)
+  }
+
+  static pageScaleRecovery() {
+    DOMEventHandlers.getCommand().executePageScaleRecovery()
+  }
+
+  static pageScaleMinus() {
+    DOMEventHandlers.getCommand().executePageScaleMinus()
+  }
+
+  static pageScaleAdd() {
+    DOMEventHandlers.getCommand().executePageScaleAdd()
+  }
+
+  static paperSize(width: number, height: number) {
+    DOMEventHandlers.getCommand().executePaperSize(width, height)
+  }
+
+  static paperDirection(payload: PaperDirection) {
+    DOMEventHandlers.getCommand().executePaperDirection(payload)
+  }
+
+  static getPaperMargin(): number[] {
+    return DOMEventHandlers.getCommand().getPaperMargin()
+  }
+
+  static setPaperMargin(payload: IMargin) {
+    DOMEventHandlers.getCommand().executeSetPaperMargin(payload)
+  }
+
+  static insertElementList(payload: IElement[]) {
+    DOMEventHandlers.getCommand().executeInsertElementList(payload)
+  }
+
+  static appendElementList(
+    elementList: IElement[],
+    options?: IAppendElementListOption
+  ) {
+    DOMEventHandlers.getCommand().executeAppendElementList(elementList, options)
+  }
+
+  static setValue(payload: Partial<IEditorData>) {
+    DOMEventHandlers.getCommand().executeSetValue(payload)
+  }
+
+  static removeControl() {
+    DOMEventHandlers.getCommand().executeRemoveControl()
+  }
+
+  static setLocale(payload: string) {
+    DOMEventHandlers.getCommand().executeSetLocale(payload)
+  }
+
+  static getCatalog(): Promise<ICatalog | null> {
+    return DOMEventHandlers.getCommand().getCatalog()
+  }
+
+  static locationCatalog(titleId: string) {
+    DOMEventHandlers.getCommand().executeLocationCatalog(titleId)
+  }
+
+  static wordTool() {
+    DOMEventHandlers.getCommand().executeWordTool()
+  }
+
+  static globalHyperlink() {
+    DOMEventHandlers.getCommand().executeGlobalHyperlink()
   }
 }

--- a/src/editor/core/command/Command.ts
+++ b/src/editor/core/command/Command.ts
@@ -93,6 +93,7 @@ export class Command {
   public getSearchNavigateInfo: CommandAdapt['getSearchNavigateInfo']
   public getContentStyles: CommandAdapt['getContentStyles']
   public executeGlobalHyperlink: CommandAdapt['globalHyperlink']
+  public getHyperlinkRange: CommandAdapt['getHyperlinkRange']
 
   constructor(adapt: CommandAdapt) {
     // 全局命令
@@ -198,5 +199,6 @@ export class Command {
     this.getPaperMargin = adapt.getPaperMargin.bind(adapt)
     this.getSearchNavigateInfo = adapt.getSearchNavigateInfo.bind(adapt)
     this.getContentStyles = adapt.getContentStyles.bind(adapt)
+    this.getHyperlinkRange = adapt.getHyperlinkRange.bind(adapt)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ window.onload = function () {
     {
       header: [
         {
-          value: "First People's Hospital",
+          value: `First People's Hospital`,
           size: 32,
           rowFlex: RowFlex.CENTER
         },


### PR DESCRIPTION
methods that still do not have a DOM wrapper in src/editor/DOMEventHandlers.ts, they are:

mode, cut, copy, paste, selectAll, backspace, setRange, painter, applyPainterStyle, format, rowMargin, insertTableTopRow, insertTableBottomRow, insertTableLeftCol, insertTableRightCol, deleteTableRow, deleteTableCol, deleteTable, mergeTableCell, cancelMergeTableCell, tableTdVerticalAlign, tableBorderType, tableTdBackgroundColor, tableTdBorderBgTop, tableTdBorderBgBottom, tableTdBorderBgLeft, tableTdBorderBgRight, tableTdBorderWidthTop, tableTdBorderWidthLeft, tableTdBorderWidthBottom, tableTdBorderWidthRight, hyperlink, getHyperlinkRange, deleteHyperlink, cancelHyperlink, editHyperlink, pageBreak, addWatermark, deleteWatermark, search, searchNavigatePre, searchNavigateNext, getSearchNavigateInfo, replace, print, replaceImageElement, saveAsImageElement, changeImageDisplay, getImage, getHTML, getWordCount, getRangeContext, pageMode, pageScaleRecovery, pageScaleMinus, pageScaleAdd, paperSize, paperDirection, appendElementList, removeControl, getCatalog, locationCatalog, wordTool
is wraped